### PR TITLE
Grab handle from session instead of raw user input

### DIFF
--- a/routes/api/poll.ts
+++ b/routes/api/poll.ts
@@ -92,7 +92,7 @@ export const handler = async (req: Request, _ctx: HandlerContext): Promise<Respo
             visible_id,
             results_posted,
             user_agent) VALUES (
-                ${handle},
+                ${agent.session!.handle},
                 ${postUri},
                 ${question},
                 ${JSON.stringify(answers)},


### PR DESCRIPTION
As it is, you can currently login via email, and accidentally expose your email address on the poll. Would be best if we just avoid inserting the raw user input to the DB.